### PR TITLE
Add ISO 8601 hint to Calendar.xml

### DIFF
--- a/xml/System.Globalization/Calendar.xml
+++ b/xml/System.Globalization/Calendar.xml
@@ -2378,7 +2378,10 @@ Only the <xref:System.Globalization.JapaneseCalendar> and the <xref:System.Globa
 -   The <xref:System.Globalization.DateTimeFormatInfo.FirstDayOfWeek%2A?displayProperty=nameWithType> property contains the default first day of the week that can be used for the `firstDayOfWeek` parameter.  
   
 -   The <xref:System.Globalization.DateTimeFormatInfo.CalendarWeekRule%2A?displayProperty=nameWithType> property contains the default calendar week rule that can be used for the `rule` parameter.  
-  
+ 
+> [!NOTE]
+> This does not map exactly to ISO 8601. The differences are discussed in the blog entry [ISO 8601 Week of Year format in Microsoft .NET](https://go.microsoft.com/fwlink/?LinkId=160851). Starting with .NET Core 3.0, <xref:System.Globalization.ISOWeek.GetYear%2A?displayProperty=nameWithType> and <xref:System.Globalization.ISOWeek.GetWeekOfYear%2A?displayProperty=nameWithType> solve this problem. 
+
  The following example uses the current culture's <xref:System.Globalization.DateTimeFormatInfo> object to determine that January 1, 2011 is in the first week of the year in the Gregorian calendar.  
   
  [!code-csharp[System.Globalization.Calendar.GetWeekOfYear#2](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Globalization.Calendar.GetWeekOfYear/CS/getweekofyearex1.cs#2)]


### PR DESCRIPTION
## Summary

This change adds the hint on ISO 8601 from `CalendarWeekRule` to `Calendar.GetWeekOfYear` too.
This helps a lot when dealing with this method without digging into the whole `CalendarWeekRule` chapter.

Fixes #3754